### PR TITLE
Nginx Ingress controller now requires ingress.class

### DIFF
--- a/demo/haproxy-auth-gateway/gateway-ingress.yaml
+++ b/demo/haproxy-auth-gateway/gateway-ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gateway-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/backend-protocol: "http"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
This is a trivial fix for a problem where after deploying the Ingress controller https://api.localtest.me/ would report a 404 Not Found error instead of the expected 403 Forbidden as reported in issue #14.

The pod logs will have an error similar to this:

`I1017 21:58:37.843115       7 store.go:426] "Ignoring ingress because of error while validating ingress class" ingress="namespace/gateway-ingress" error="ingress does not contain a valid IngressClass"
`

