### PR TITLE
Keycloak 20.0.2 upgrade

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup Kubernetes
       uses: debianmaster/actions-k3s@master
       with:
-        version: 'v1.21.2-k3s1'
+        version: 'v1.26.0-k3s1'
 
     - name: Deploy Keycloak
       run: ./deploy-local-cluster.sh

--- a/keycloak-eks-placeholder.yaml
+++ b/keycloak-eks-placeholder.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:19.0.3
+          image: quay.io/keycloak/keycloak:20.0.2
           args: ["start", "--cache-stack=kubernetes"]
           volumeMounts:
           - name: certs

--- a/keycloak.yaml
+++ b/keycloak.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:19.0.3
+          image: quay.io/keycloak/keycloak:20.0.2
           args: ["start", "--cache-stack=kubernetes"]
           volumeMounts:
           - name: certs


### PR DESCRIPTION
Upgraded Keycloak to 20.0.2. 

Also, this pull request contains github workflow update of k3s to use v1.26.0-k3s1 (latest as of creating this pull request). The older k3s version stopped working and workflow started to fail.